### PR TITLE
fix(components): 调整OCR扫描按钮位置从顶部到底部

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -210,7 +210,7 @@ export const Home: React.FC = () => {
                 {/* OCR 扫描按钮 */}
                 <button
                   onClick={() => setShowCamera(true)}
-                  className="absolute top-3 right-3 md:top-4 md:right-4 flex items-center gap-1.5 px-3 py-1.5 md:px-4 md:py-2 bg-gradient-to-r from-fun-purple to-fun-pink text-white text-xs md:text-sm font-bold rounded-lg shadow-lg shadow-fun-purple/20 hover:shadow-xl hover:shadow-fun-purple/30 hover:-translate-y-0.5 active:translate-y-0 transition-all"
+                  className="absolute bottom-3 right-3 md:bottom-4 md:right-4 flex items-center gap-1.5 px-3 py-1.5 md:px-4 md:py-2 bg-gradient-to-r from-fun-purple to-fun-pink text-white text-xs md:text-sm font-bold rounded-lg shadow-lg shadow-fun-purple/20 hover:shadow-xl hover:shadow-fun-purple/30 hover:-translate-y-0.5 active:translate-y-0 transition-all"
                 >
                   <ScanLine size={14} className="md:w-4 md:h-4" />
                   {t('home.ocr_scan')}


### PR DESCRIPTION
将Home组件中的OCR扫描按钮定位从top改为bottom，使其显示在页面底部而非顶部，
提升用户界面布局的一致性和可用性。


<img width="1998" height="1442" alt="image" src="https://github.com/user-attachments/assets/ed13f53c-ea0b-4a36-bb55-4569cda616b3" />

<img width="704" height="1110" alt="image" src="https://github.com/user-attachments/assets/0087e980-2213-463e-ab5d-05bc5c7f5993" />
